### PR TITLE
BF: added setup tools to run dependencies since we use pkg_resources

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - datalad=datalad.cmdline.main:main
     - git-annex-remote-datalad-archives=datalad.customremotes.archives:main
@@ -62,6 +62,7 @@ requirements:
     - requests >=1.2
     - requests-ftp
     - secretstorage  # [linux and py>32]
+    - setuptools
     - simplejson
     - six >=1.8.0
     - tqdm


### PR DESCRIPTION
downstream testing done by @notestaff reported failure in https://github.com/conda-forge/git-annex-feedstock/pull/104

```
2020-10-13T17:26:04.4077828Z import: 'datalad'
2020-10-13T17:26:04.4838554Z It is highly recommended to configure Git before using DataLad. Set both 'user.name' and 'user.email' configuration variables.
2020-10-13T17:26:04.4839782Z It is highly recommended to configure Git before using DataLad. Set both 'user.name' and 'user.email' configuration variables.
2020-10-13T17:26:04.5768564Z Traceback (most recent call last):
2020-10-13T17:26:04.5770487Z   File "/home/conda/feedstock_root/build_artifacts/git-annex_1602602073830/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/bin/datalad", line 11, in <module>
2020-10-13T17:26:04.5774027Z     sys.exit(main())
2020-10-13T17:26:04.5775648Z   File "/home/conda/feedstock_root/build_artifacts/git-annex_1602602073830/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.7/site-packages/datalad/cmdline/main.py", line 436, in main
2020-10-13T17:26:04.5781993Z     parser = setup_parser(args)
2020-10-13T17:26:04.5783592Z   File "/home/conda/feedstock_root/build_artifacts/git-annex_1602602073830/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.7/site-packages/datalad/cmdline/main.py", line 226, in setup_parser
2020-10-13T17:26:04.5784452Z     add_entrypoints_to_interface_groups(interface_groups)
2020-10-13T17:26:04.5785702Z   File "/home/conda/feedstock_root/build_artifacts/git-annex_1602602073830/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placeh/lib/python3.7/site-packages/datalad/cmdline/main.py", line 398, in add_entrypoints_to_interface_groups
2020-10-13T17:26:04.5789985Z     from pkg_resources import iter_entry_points  # delay expensive import
2020-10-13T17:26:04.5790786Z ModuleNotFoundError: No module named 'pkg_resources'
2020-10-13T17:26:06.0804119Z Tests failed for datalad-0.12.6-py37hc8dfbb8_0.tar.bz2 - moving package to /home/conda/feedstock_root/build_artifacts/broken
2020-10-13T17:26:06.0805854Z WARNING:conda_build.build:Tests failed for datalad-0.12.6-py37hc8dfbb8_0.tar.bz2 - moving package to /home/conda/feedstock_root/build_artifacts/broken
2020-10-13T17:26:06.0807052Z WARNING conda_build.build:tests_failed(2889): Tests failed for datalad-0.12.6-py37hc8dfbb8_0.tar.bz2 - moving package to /home/conda/feedstock_root/build_artifacts/broken
2020-10-13T17:26:06.1218664Z TESTS FAILED: datalad-0.12.6-py37hc8dfbb8_0.tar.bz2
2020-10-13T17:26:16.6218798Z
2020-10-13T17:26:16.6701060Z ##[error]Bash exited with code '1'.
2020-10-13T17:26:16.6725808Z ##[section]Finishing: Run docker build
```

so it seems that we indeed need setuptools which should provide `pkg_resources` AFAIK at `run` time