### PR TITLE
Revert "BF: we need posix package for bash, sed, etc on windows"

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - datalad=datalad.cmdline.main:main
     - git-annex-remote-datalad-archives=datalad.customremotes.archives:main
@@ -55,7 +55,6 @@ requirements:
     - pyperclip
     - pyyaml
     - pillow
-    - posix  # [win]
     - python
     - python-dateutil
     # TODO


### PR DESCRIPTION
This reverts commit 367688eb7f73bcfb192f1ebf9d1cd7552a7bb2c5.

Unfortunately bash from m2- set of packages is not a suitable fit ATM.  It
rewrites PATH so no conda-forge installed packages binaries are seen inside.
See https://github.com/ContinuumIO/anaconda-issues/issues/12124

There seems possibly additional side effects (e.g. `conda` itself which is .bat
is not found inside that bash session).
