### PR TITLE
Set minimum importlib-metadata to 3.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - git  # [not win]
     - git-annex  # [linux]
     - humanize
-    - importlib-metadata >=3.6 # [py<310]
+    - importlib-metadata >=3.6  # [py<310]
     - iso8601
     - keyring >=8.0
     - keyrings.alt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - git  # [not win]
     - git-annex  # [linux]
     - humanize
-    - importlib-metadata  # [py<310]
+    - importlib-metadata >=3.6 # [py<310]
     - iso8601
     - keyring >=8.0
     - keyrings.alt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - datalad=datalad.cmdline.main:main
     - git-annex-remote-datalad-archives=datalad.customremotes.archives:main


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Applies https://github.com/datalad/datalad/pull/6631 to conda package metadata, which seems like a reasonable thing to include even before it lands in 0.16.2.