### PR TITLE
Revert back to have it noarch: python

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,7 @@ source:
 
 build:
   number: 0
+  noarch: python
   entry_points:
     - datalad=datalad.cmdline.main:main
     - git-annex-remote-datalad-archives=datalad.customremotes.archives:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - datalad=datalad.cmdline.main:main


### PR DESCRIPTION
goal: make it available for OSX-arm64

alternative to: https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/4422 where datalad would get queued for migration builds for osx-arm64

Originally we removed this line in https://github.com/conda-forge/datalad-feedstock/commit/170c8520b69fb5ae1ac86039f2383cef61235270 to resolve some issue with python2.7.  also I thought it was needed to run tests on each of the architectures.  Well -- ATM we can run tests only on linux since there is no git-annex build for any other (BTW -- may be we should just install there using datalad-installer for now? orthogonal to this).
So if that is true, i.e. no tests running, then we might abandon this PR.